### PR TITLE
fix: add network between container in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     entrypoint: ["./entrypoint.sh", "reflex", "-c", "reflex.conf"]
     depends_on:
       - db
+    networks:
+      - APP
+    ports:
+      - ${PORT}:${PORT}
 
   db:
     container_name: "geo-db"
@@ -22,6 +26,8 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
       - ${DB_PORT}:27017
+    networks:
+      - APP
 
   mongo-express:
     image: mongo-express
@@ -32,5 +38,11 @@ services:
       ME_CONFIG_MONGODB_ADMINUSERNAME: ${DB_USER}
       ME_CONFIG_MONGODB_ADMINPASSWORD: ${DB_PASSWORD}
       ME_CONFIG_MONGODB_URL: mongodb://${DB_USER}:${DB_PASSWORD}@db:${DB_PORT}/
+    networks:
+      - APP
     depends_on:
       - db
+
+networks:
+  APP:
+    name: app

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.9.5 h1:U+CaK85mrNNb4k8BNOfgJtJ/gr6kswUCFj6miSzVC6M=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/infrastructure/mongodb_handler.go
+++ b/infrastructure/mongodb_handler.go
@@ -27,7 +27,9 @@ var ctx = context.TODO()
 
 func NewMongoDBHandler() (interfaces.NoSQLHandler, error) {
 	noSqlHandler := &Collection{}
-	clientOptions := options.Client().ApplyURI(fmt.Sprintf("mongodb://db:%s", os.Getenv("DB_PORT")))
+	clientOptions := options.Client().ApplyURI(
+		fmt.Sprintf("mongodb://%s:%s@db:%s", os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_PORT")),
+	)
 	client, err := mongo.Connect(ctx, clientOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Task/Feature:
Fix run application with docker-compose, 
Application cannot communicate with mongodb 
Fix api to use DB_USER and DB_PASSWORD to connect with mongodb

### Changes introduced by this pull request:

- docker-compose.yaml
- mongo_db_handler

